### PR TITLE
fixes a compiler error where bool signal name conflicted with a system d...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+rtl_zwave

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ G.9959 frames are FSK/NRZ and FSK/Manchester encoded. Supported bitrates are
 
 
     rtl_sdr -f 868.1e6 -s 2048000 -g 25  - |./rtl_zniffer
+    
+### USA
+
+	rtl_sdr -f 908.42e6 -s 2048000 -g 25  - |./rtl_zwave
 
 This is my first signaling processing project, so it might not be perfect. 
-I'm pretty sure there is room for impovement in the algorithms. 
+I'm pretty sure there is room for improvement in the algorithms. 

--- a/rtl_zwave.cpp
+++ b/rtl_zwave.cpp
@@ -226,7 +226,7 @@ double bit_len = 0;
 double bit_cnt = 0.0;
 double wc = 0; //  # center frequency
 bool last_logic = false;
-bool signal = false;
+bool hasSignal = false;
 bool msc; //Manchester
 const int lead_in = 10;
 double dr; //Datarate
@@ -315,14 +315,14 @@ int main(int argc, char** argv)
           # 1/2 seperation, TODO calculate 1/2 seperation
            */
           /*if(state == S_BITLOCK) {
-            signal = fabs(wc - lock) < 0.1;
+            hasSignal = fabs(wc - lock) < 0.1;
             printf("lock lost %f\n",fabs(wc - lock));
             } else {*/
-          signal = fabs(lock) > 0.01;
+          hasSignal = fabs(lock) > 0.01;
           /*}*/
 
 
-          if (signal)
+          if (hasSignal)
             {
               bool logic = (s - wc) < 0;
 


### PR DESCRIPTION
I was getting compile error on my machine because "signal" was already defined in signal.h so I just renamed the variable.
